### PR TITLE
Add scripts to build extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,5 +7,6 @@
 				"stylelint.vscode-stylelint"
 			]
 		}
-	}
+	},
+	"postCreateCommand": "chmod +x ./scripts/build.sh"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-node_modules
+builds/

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,6 +1,4 @@
 {
-    // See https://go.microsoft.com/fwlink/?LinkId=733558
-    // for the documentation about the tasks.json format
     "version": "2.0.0",
     "tasks": [
         {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
         {
             "label": "Build extension",
             "type": "shell",
-            "command": "chmod +x ./scripts/build.sh && ./scripts/build.sh",
+            "command": "./scripts/build.sh",
             "group": {
                 "kind": "build",
                 "isDefault": true

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build extension",
+            "type": "shell",
+            "command": "chmod +x ./scripts/build.sh && ./scripts/build.sh",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,22 +4,32 @@ set -e
 echo "Building Classroom Dark Mode extension..."
 
 VERSION=$(grep -oP '"version":\s*"\K[0-9.]+(?=")' src/manifest.json)
-CHROMIUM_BUILD_DIR="builds/ClassroomDarkMode-$VERSION-chromium"
-FIREFOX_BUILD_DIR="builds/ClassroomDarkMode-$VERSION-firefox"
+BUILD_DIR="builds"
+CHROMIUM_FOLDER="ClassroomDarkMode-$VERSION-chromium"
+FIREFOX_FOLDER="ClassroomDarkMode-$VERSION-firefox"
+
+# Setup build directory
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+cd "$BUILD_DIR"
 
 # Build Chromium extension
-mkdir -p "$CHROMIUM_BUILD_DIR"
-cp -r src/* "$CHROMIUM_BUILD_DIR"
-rm "$CHROMIUM_BUILD_DIR/manifest.firefox.json"
-zip -rq "$CHROMIUM_BUILD_DIR.zip" "$CHROMIUM_BUILD_DIR"
+mkdir -p "$CHROMIUM_FOLDER"
+cp -r ../src/* "$CHROMIUM_FOLDER"
+rm "$CHROMIUM_FOLDER/manifest.firefox.json"
+cd "$CHROMIUM_FOLDER"
+zip -rq "../$CHROMIUM_FOLDER.zip" *
+cd ..
 echo "Chromium extension built successfully"
 
 # Build Firefox extension
-mkdir -p "$FIREFOX_BUILD_DIR"
-cp -r src/* "$FIREFOX_BUILD_DIR"
-cp "$FIREFOX_BUILD_DIR/manifest.firefox.json" "$FIREFOX_BUILD_DIR/manifest.json"
-rm "$FIREFOX_BUILD_DIR/manifest.firefox.json"
-zip -rq "$FIREFOX_BUILD_DIR.zip" "$FIREFOX_BUILD_DIR"
+mkdir -p "$FIREFOX_FOLDER"
+cp -r ../src/* "$FIREFOX_FOLDER"
+cp "$FIREFOX_FOLDER/manifest.firefox.json" "$FIREFOX_FOLDER/manifest.json"
+rm "$FIREFOX_FOLDER/manifest.firefox.json"
+cd "$FIREFOX_FOLDER"
+zip -rq "../$FIREFOX_FOLDER.zip" *
+cd ..
 echo "Firefox extension built successfully"
 
 echo "Build completed successfully!"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+set -e
+
+echo "Building Classroom Dark Mode extension..."
 
 VERSION=$(grep -oP '"version":\s*"\K[0-9.]+(?=")' src/manifest.json)
 CHROMIUM_BUILD_DIR="builds/ClassroomDarkMode-$VERSION-chromium"
@@ -8,13 +11,15 @@ FIREFOX_BUILD_DIR="builds/ClassroomDarkMode-$VERSION-firefox"
 mkdir -p "$CHROMIUM_BUILD_DIR"
 cp -r src/* "$CHROMIUM_BUILD_DIR"
 rm "$CHROMIUM_BUILD_DIR/manifest.firefox.json"
-zip -r "$CHROMIUM_BUILD_DIR.zip" "$CHROMIUM_BUILD_DIR"
+zip -rq "$CHROMIUM_BUILD_DIR.zip" "$CHROMIUM_BUILD_DIR"
+echo "Chromium extension built successfully"
 
 # Build Firefox extension
 mkdir -p "$FIREFOX_BUILD_DIR"
 cp -r src/* "$FIREFOX_BUILD_DIR"
 cp "$FIREFOX_BUILD_DIR/manifest.firefox.json" "$FIREFOX_BUILD_DIR/manifest.json"
 rm "$FIREFOX_BUILD_DIR/manifest.firefox.json"
-zip -r "$FIREFOX_BUILD_DIR.zip" "$FIREFOX_BUILD_DIR"
+zip -rq "$FIREFOX_BUILD_DIR.zip" "$FIREFOX_BUILD_DIR"
+echo "Firefox extension built successfully"
 
 echo "Build completed successfully!"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,6 +9,7 @@ CHROMIUM_FOLDER="ClassroomDarkMode-$VERSION-chromium"
 FIREFOX_FOLDER="ClassroomDarkMode-$VERSION-firefox"
 
 # Setup build directory
+echo "Cleaning up build directory..."
 rm -rf "$BUILD_DIR"
 mkdir -p "$BUILD_DIR"
 cd "$BUILD_DIR"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+VERSION=$(grep -oP '"version":\s*"\K[0-9.]+(?=")' src/manifest.json)
+CHROMIUM_BUILD_DIR="builds/ClassroomDarkMode-$VERSION-chromium"
+FIREFOX_BUILD_DIR="builds/ClassroomDarkMode-$VERSION-firefox"
+
+# Build Chromium extension
+mkdir -p "$CHROMIUM_BUILD_DIR"
+cp -r src/* "$CHROMIUM_BUILD_DIR"
+rm "$CHROMIUM_BUILD_DIR/manifest.firefox.json"
+zip -r "$CHROMIUM_BUILD_DIR.zip" "$CHROMIUM_BUILD_DIR"
+
+# Build Firefox extension
+mkdir -p "$FIREFOX_BUILD_DIR"
+cp -r src/* "$FIREFOX_BUILD_DIR"
+cp "$FIREFOX_BUILD_DIR/manifest.firefox.json" "$FIREFOX_BUILD_DIR/manifest.json"
+rm "$FIREFOX_BUILD_DIR/manifest.firefox.json"
+zip -r "$FIREFOX_BUILD_DIR.zip" "$FIREFOX_BUILD_DIR"
+
+echo "Build completed successfully!"


### PR DESCRIPTION
## Description

Adds scripts for building the extension directory and ZIP.

## Related Issues

<!-- List any related issues or pull requests that are being resolved or addressed by this pull request.

Example:
Closes #issue_number

Replace issue_number with the issue number to mark it -->

## Changes Made

* [`.devcontainer/devcontainer.json`](diffhunk://#diff-24ad71c8613ddcf6fd23818cb3bb477a1fb6d83af4550b0bad43099813088686L10-R11): Added a `postCreateCommand` to make the `build.sh` script executable.
* [`.vscode/tasks.json`](diffhunk://#diff-7d76d7533653c23b753fc7ce638cf64bdb5e419927d276af836d3a03fdf1745aR1-R16): Created a new VS Code task to build the extension using the `build.sh` script.
* [`scripts/build.sh`](diffhunk://#diff-3d64996115d0ac3b74e36f57ce6b00d6b4982614c41b1ed39eab8ef43b2e9a2bR1-R36): Implemented a new build script to automate the building of the Classroom Dark Mode extension for both Chromium and Firefox.

## Checklist

<!-- Please check off the following items before submitting your pull request: 

Example:
- [x] I have checked this box

Simply put an "x" between the brackets like here to check it -->

- [x] I have tested these changes thoroughly.
- [x] I have reviewed my code for any potential errors or issues.
- [x] I have followed the code style guidelines for this project.

## Additional Notes

<!-- Provide any additional information or notes that may be helpful in reviewing this pull request. -->

## Code of Conduct

By submitting this issue, I agree to follow the [Code of Conduct](CODE_OF_CONDUCT.md).
