### PR TITLE
Fix quick links hover color

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1716,3 +1716,8 @@ input.tAUuQ {
   background-color: var(--bg-color) !important;
   box-shadow: 0 1px 3px 0 var(--shadow-heavy), 0 4px 8px 3px var(--shadow-medium) !important;
 }
+
+/* Quick Links */
+.YLFC3e:hover, .YLFC3e:focus, .YLFC3e:focus-within {
+  background-color: var(--white-hover);
+}


### PR DESCRIPTION
## Description

Fixes the quick links hover color.

### Before

![image](https://github.com/user-attachments/assets/6ae53d79-3db1-4552-9916-f50930aa84d5)

### After

![image](https://github.com/user-attachments/assets/4c78e209-df86-4256-ab63-897ef3ffc2d7)

## Related Issues

<!-- List any related issues or pull requests that are being resolved or addressed by this pull request.

Example:
Closes #issue_number

Replace issue_number with the issue number to mark it -->

## Changes Made

* [`src/style.css`](diffhunk://#diff-1104bdfdc4d3b01a85d7af489598121125db6bc016db2a48a083ef654c97b0f5R1719-R1723): Added new CSS rules to style the `.YLFC3e` class with a background color change on hover, focus, and focus-within states.
<!-- Describe the changes that were made in this pull request. Be as detailed as possible. -->

## Checklist

<!-- Please check off the following items before submitting your pull request: 

Example:
- [x] I have checked this box

Simply put an "x" between the brackets like here to check it -->

- [x] I have tested these changes thoroughly.
- [x] I have reviewed my code for any potential errors or issues.
- [x] I have followed the code style guidelines for this project.

## Additional Notes

<!-- Provide any additional information or notes that may be helpful in reviewing this pull request. -->