### PR TITLE
Fix app menu icon

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -42,6 +42,10 @@ body {
 }
 
 /* Navbar */
+.gb_Ea svg,.gb_Oc svg, .gb_rd .gb_sd, .gb_1c .gb_sd {
+  color: var(--font-color) !important;
+}
+
 .gb_Pa svg,
 .gb_Tc svg,
 .gb_fd .gb_od,


### PR DESCRIPTION
## Description

Fixes a rare case scenario where if the viewport was small enough, the app icon would use the non-dark theme colors.

### Before 
![image](https://github.com/user-attachments/assets/9fe45b20-f77b-4b0e-a9a1-43a185c0c20d)

### After
![image](https://github.com/user-attachments/assets/a02c1fc5-b546-4040-b6e7-852bbc9aeedb)

## Related Issues

<!-- List any related issues or pull requests that are being resolved or addressed by this pull request.

Example:
Closes #issue_number

Replace issue_number with the issue number to mark it -->

## Changes Made

* [`src/style.css`](diffhunk://#diff-1104bdfdc4d3b01a85d7af489598121125db6bc016db2a48a083ef654c97b0f5R45-R48): Added a new rule to set the color of `.gb_Ea svg`, `.gb_Oc svg`, `.gb_rd .gb_sd`, and `.gb_1c .gb_sd` elements to `var(--font-color) !important`.

## Checklist

<!-- Please check off the following items before submitting your pull request: 

Example:
- [x] I have checked this box

Simply put an "x" between the brackets like here to check it -->

- [x] I have tested these changes thoroughly.
- [x] I have reviewed my code for any potential errors or issues.
- [x] I have followed the code style guidelines for this project.

## Additional Notes

<!-- Provide any additional information or notes that may be helpful in reviewing this pull request. -->