### PR TITLE
Fix skip to main content background

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1721,3 +1721,9 @@ input.tAUuQ {
 .YLFC3e:hover, .YLFC3e:focus, .YLFC3e:focus-within {
   background-color: var(--white-hover) !important;
 }
+
+/* Skip to main content */
+.EXL71e {
+  box-shadow: 0 1px 2px 0 var(--shadow-heavy), 0 2px 6px 2px var(--shadow-medium);
+  background: var(--bg-color) !important;
+}


### PR DESCRIPTION
## Description

Fixes the background for the "skip to main content" button.

### Before

![image](https://github.com/user-attachments/assets/6d359a15-d35a-4d74-95b0-175d2d3190e2)

### After

![image](https://github.com/user-attachments/assets/b93a3b6a-f5a2-4b65-9244-4bf2d7c6a5c6)

## Related Issues

<!-- List any related issues or pull requests that are being resolved or addressed by this pull request.

Example:
Closes #issue_number

Replace issue_number with the issue number to mark it -->

## Changes Made

* [`src/style.css`](diffhunk://#diff-1104bdfdc4d3b01a85d7af489598121125db6bc016db2a48a083ef654c97b0f5R1724-R1729): Added a new CSS class `.EXL71e` to apply box shadow and background color to the "Skip to main content" button.

## Checklist

<!-- Please check off the following items before submitting your pull request: 

Example:
- [x] I have checked this box

Simply put an "x" between the brackets like here to check it -->

- [x] I have tested these changes thoroughly.
- [x] I have reviewed my code for any potential errors or issues.
- [x] I have followed the code style guidelines for this project.

## Additional Notes

<!-- Provide any additional information or notes that may be helpful in reviewing this pull request. -->