### PR TITLE
Force light on embed backgrounds

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1731,3 +1731,8 @@ input.tAUuQ {
   box-shadow: 0 1px 2px 0 var(--shadow-heavy), 0 2px 6px 2px var(--shadow-medium) !important;
   background: var(--bg-color) !important;
 }
+
+/* Embed background */
+iframe {
+  color-scheme: light;
+}


### PR DESCRIPTION
## Description

Forces light mode on embedded content in order not to break them from custom CSS.

### Before

![image](https://github.com/user-attachments/assets/cf2c89d1-61e9-4c83-9a2f-732201b82a68)

### After

![image](https://github.com/user-attachments/assets/a1fd1622-7014-4b9b-9943-12d5b307c5eb)

## Related Issues

Closes #112 

<!-- List any related issues or pull requests that are being resolved or addressed by this pull request.

Example:
Closes #issue_number

Replace issue_number with the issue number to mark it -->

## Changes Made

* Set the `color-scheme` for `iframe`s to light

## Checklist

<!-- Please check off the following items before submitting your pull request: 

Example:
- [x] I have checked this box

Simply put an "x" between the brackets like here to check it -->

- [x] I have tested these changes thoroughly.
- [x] I have reviewed my code for any potential errors or issues.
- [x] I have followed the code style guidelines for this project.

## Additional Notes

<!-- Provide any additional information or notes that may be helpful in reviewing this pull request. -->