### PR TITLE
Fixed the "Google Apps" top Navbar icon's styling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 builds/
+.idea/
+.idea_modules/

--- a/src/style.css
+++ b/src/style.css
@@ -49,6 +49,10 @@ body {
   color: var(--font-color) !important;
 }
 
+.gb_F {
+  fill: var(--font-color) !important;
+}
+
 .gb_Fa svg,
 .gb_Pc svg,
 .gb_sd .gb_td,
@@ -185,7 +189,8 @@ body {
 
 .ETRkCe {
   background-color: var(--bg-color) !important;
-  box-shadow: 0 4px 4px 0 var(--shadow-heavy), 0 8px 12px 6px var(--shadow-medium);
+  box-shadow: 0 4px 4px 0 var(--shadow-heavy),
+    0 8px 12px 6px var(--shadow-medium);
 }
 
 .Tabkde .OX4Vcb {
@@ -306,7 +311,7 @@ body {
 }
 
 /* Join Classroom */
-.xiutKc>.I7OXgf {
+.xiutKc > .I7OXgf {
   background-color: var(--bg-color) !important;
 }
 
@@ -592,7 +597,10 @@ body {
 }
 
 .f8nwhd-qb23S-b9nz9e-OWXEXe-gk6SMd {
-  background-color: var(--gm3-segmented-button-outlined-selected-container-color, var(--gm3-sys-color-secondary-container, #c2e7ff));
+  background-color: var(
+    --gm3-segmented-button-outlined-selected-container-color,
+    var(--gm3-sys-color-secondary-container, #c2e7ff)
+  );
 }
 
 .ycbm1d {
@@ -1667,8 +1675,8 @@ input.tAUuQ {
   border-color: var(--bd-color) !important;
 }
 
-.jsbB5e.IYewr>.Yalane>.oQ5Hqe,
-.jsbB5e.IYewr>.Yalane>.aCxcAe {
+.jsbB5e.IYewr > .Yalane > .oQ5Hqe,
+.jsbB5e.IYewr > .Yalane > .aCxcAe {
   background-color: #d93025 !important;
 }
 
@@ -1676,7 +1684,7 @@ input.tAUuQ {
   caret-color: #d93025 !important;
 }
 
-.W9wDc.IYewr .poFWNe:not([disabled]):focus~.qTs5Xc,
+.W9wDc.IYewr .poFWNe:not([disabled]):focus ~ .qTs5Xc,
 .W9wDc.IYewr .n9IS1 .qTs5Xc {
   color: #d93025 !important;
 }
@@ -1733,7 +1741,8 @@ input.tAUuQ {
   background-color: var(--bd-secondary-color) !important;
 }
 
-.ndfHFb-c4YZDc-i5oIFb .ndfHFb-c4YZDc-j7LFlb-Bz112c.ndfHFb-c4YZDc-C7uZwb-LgbsSe-Bz112c,
+.ndfHFb-c4YZDc-i5oIFb
+  .ndfHFb-c4YZDc-j7LFlb-Bz112c.ndfHFb-c4YZDc-C7uZwb-LgbsSe-Bz112c,
 .ndfHFb-c4YZDc-i5oIFb .ndfHFb-c4YZDc-bN97Pc-nupQLb-LgbsSe-Bz112c {
   filter: invert(1) !important;
 }
@@ -1764,7 +1773,8 @@ input.tAUuQ {
 /* Mark As Done/Unsubmit Confirmation */
 .cC1eCc .VfPpkd-P5QLlc {
   background-color: var(--bg-color) !important;
-  box-shadow: 0 1px 3px 0 var(--shadow-heavy), 0 4px 8px 3px var(--shadow-medium) !important;
+  box-shadow: 0 1px 3px 0 var(--shadow-heavy),
+    0 4px 8px 3px var(--shadow-medium) !important;
 }
 
 /* Quick Links */
@@ -1776,7 +1786,8 @@ input.tAUuQ {
 
 /* Skip to main content */
 .EXL71e {
-  box-shadow: 0 1px 2px 0 var(--shadow-heavy), 0 2px 6px 2px var(--shadow-medium) !important;
+  box-shadow: 0 1px 2px 0 var(--shadow-heavy),
+    0 2px 6px 2px var(--shadow-medium) !important;
   background: var(--bg-color) !important;
 }
 
@@ -1809,7 +1820,8 @@ input.tAUuQ {
 }
 
 .hmG2yf:hover {
-  box-shadow: 0 1px 2px 0 var(--shadow-medium), 0 2px 6px 2px var(--shadow-medium) !important;
+  box-shadow: 0 1px 2px 0 var(--shadow-medium),
+    0 2px 6px 2px var(--shadow-medium) !important;
 }
 
 .Rvesne {


### PR DESCRIPTION
## Description

Currently, the "Google Apps" icon in the navbar is grey, when it should be white to match the other icons in the navbar.
This PR makes the google apps icon white.

## Related Issues

None

## Changes Made

1. Made fill color for the Google Apps SVG icon "white"
2. My reformatter reformatted some lines in the code.

## Checklist

<!-- Please check off the following items before submitting your pull request: 

Example:
- [x] I have checked this box

Simply put an "x" between the brackets like here to check it -->

- [x] I have tested these changes thoroughly.
- [x] I have reviewed my code for any potential errors or issues.
- [x] I have followed the code style guidelines for this project.

## Additional Notes

This is the current icon:(NOTE: The box around the icon is set by me)
<img width="160" alt="image" src="https://github.com/user-attachments/assets/fb9986a7-8ec7-4142-a58a-e85bf140bae1" />

This is the new icon:
<img width="147" alt="image" src="https://github.com/user-attachments/assets/bfad324a-e5e7-4e02-8660-08ccaf2a019f" />

I have tested these changes on Chrome and Edge
